### PR TITLE
Add CursorScript to Main Camera

### DIFF
--- a/Assets/Scenes/displayCard.unity
+++ b/Assets/Scenes/displayCard.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f4c941f51b2e8d6cfce095e18312e3667d637995b1d31246f02dcd8c678d836
-size 411018
+oid sha256:468fa4af93a589acb85718b08ec3b8ff80d415e37100020ee8b90c9e2d2d68da
+size 411410


### PR DESCRIPTION
Right click to unlock/lock the cursor. This way, the cursor doesn't fly outside of the scene during Play